### PR TITLE
ESP-IDF v5 Upgrade

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,2 @@
+[tools]
+python = "3"

--- a/arch/esp32/esp32.ini
+++ b/arch/esp32/esp32.ini
@@ -2,7 +2,7 @@
 [esp32_base]
 extends = arduino_base
 custom_esp32_kind = esp32
-platform = platformio/espressif32@6.9.0
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/51.03.07/platform-espressif32.zip
 
 build_src_filter = 
   ${arduino_base.build_src_filter} -<platform/nrf52/> -<platform/stm32wl> -<platform/rp2xx0> -<mesh/eth/> -<mesh/raspihttp>
@@ -19,6 +19,7 @@ board_build.filesystem = littlefs
 build_unflags = -fno-lto
 build_flags =
   ${arduino_base.build_flags}
+  -fpermissive
   -flto
   -Wall
   -Wextra
@@ -43,7 +44,7 @@ lib_deps =
   ${arduino_base.lib_deps}
   ${networking_base.lib_deps}
   ${environmental_base.lib_deps}
-  https://github.com/meshtastic/esp32_https_server.git#23665b3adc080a311dcbb586ed5941b5f94d6ea2
+  https://github.com/jasenk2/esp32_https_server.git#esp_tls
   h2zero/NimBLE-Arduino@^1.4.2
   https://github.com/dbSuS/libpax.git#7bcd3fcab75037505be9b122ab2b24cc5176b587
   lewisxhe/XPowersLib@^0.2.6

--- a/patches/lib_device-ui_skooch_patch.diff
+++ b/patches/lib_device-ui_skooch_patch.diff
@@ -1,0 +1,35 @@
+diff --git a/source/TFTView_320x240.cpp b/source/TFTView_320x240.cpp
+index 62e090f..230f9e2 100644
+--- a/source/TFTView_320x240.cpp
++++ b/source/TFTView_320x240.cpp
+@@ -2494,7 +2494,7 @@ void TFTView_320x240::addMessage(uint32_t requestId, char *msg)
+     lv_obj_t *textLabel = lv_label_create(hiddenPanel);
+     // calculate expected size of text bubble, to make it look nicer
+     lv_coord_t width = lv_txt_get_width(msg, strlen(msg), &ui_font_montserrat_12, 0);
+-    lv_obj_set_width(textLabel, std::max(std::min(width + 20, 200), 40));
++    lv_obj_set_width(textLabel, std::max(std::min(width + 20, 200L), 40L));
+     lv_obj_set_height(textLabel, LV_SIZE_CONTENT);
+     lv_obj_set_y(textLabel, 0);
+     lv_obj_set_align(textLabel, LV_ALIGN_RIGHT_MID);
+@@ -3208,10 +3208,10 @@ void TFTView_320x240::handlePositionResponse(uint32_t from, uint32_t request_id,
+ 
+ #if defined(USE_SX127x)
+             int p_snr = ((std::max(rx_snr, -19.0f) + 19.0f) / 33.0f) * 100.0f; // range -19..14
+-            int p_rssi = ((std::max(rx_rssi, -145) + 145) * 100) / 90;         // range -145..-55
++            int p_rssi = ((std::max(rx_rssi, -145L) + 145) * 100) / 90;         // range -145..-55
+ #else
+             int p_snr = ((std::max(rx_snr, -18.0f) + 18.0f) / 26.0f) * 100.0f; // range -18..8
+-            int p_rssi = ((std::max(rx_rssi, -125) + 125) * 100) / 100;        // range -125..-25
++            int p_rssi = ((std::max(rx_rssi, -125L) + 125) * 100) / 100;        // range -125..-25
+ #endif
+             sprintf(buf, "%d%%", std::min((p_snr + p_rssi * 2) / 3, 100));
+             lv_label_set_text(objects.signal_scanner_start_label, buf);
+@@ -3891,7 +3891,7 @@ void TFTView_320x240::newMessage(uint32_t nodeNum, lv_obj_t *container, uint8_t
+     lv_obj_t *msgLabel = lv_label_create(hiddenPanel);
+     // calculate expected size of text bubble, to make it look nicer
+     lv_coord_t width = lv_txt_get_width(msg, strlen(msg), &ui_font_montserrat_12, 0);
+-    lv_obj_set_width(msgLabel, std::max(std::min(width + 20, 200), 40));
++    lv_obj_set_width(msgLabel, std::max(std::min(width + 20, 200L), 40L));
+     lv_obj_set_height(msgLabel, LV_SIZE_CONTENT); /// 1
+     lv_obj_set_align(msgLabel, LV_ALIGN_LEFT_MID);
+     lv_label_set_text(msgLabel, msg);

--- a/patches/pio_libdeps_t-deck_esp32_https_server_skooch.diff
+++ b/patches/pio_libdeps_t-deck_esp32_https_server_skooch.diff
@@ -1,0 +1,45 @@
+diff --git a/src/HTTPConnection.cpp b/src/HTTPConnection.cpp
+index 553a36c..b983b9b 100644
+--- a/src/HTTPConnection.cpp
++++ b/src/HTTPConnection.cpp
+@@ -664,7 +664,7 @@ void handleWebsocketHandshake(HTTPRequest * req, HTTPResponse * res) {
+ std::string websocketKeyResponseHash(std::string const &key) {
+   std::string newKey = key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+   uint8_t shaData[HTTPS_SHA1_LENGTH];
+-  mbedtls_sha1_ret((uint8_t*)newKey.data(), newKey.length(), shaData);
++  mbedtls_sha1((uint8_t*)newKey.data(), newKey.length(), shaData);
+ 
+   // Get output size required for base64 representation
+   size_t b64BufferSize = 0;
+diff --git a/src/SSLCert.cpp b/src/SSLCert.cpp
+index 3df7073..99bf446 100644
+--- a/src/SSLCert.cpp
++++ b/src/SSLCert.cpp
+@@ -160,6 +160,9 @@ static int cert_write(SSLCert &certCtx, std::string dn, std::string validityFrom
+   mbedtls_pk_context key;
+   mbedtls_x509write_cert crt;
+   mbedtls_mpi serial;
++  unsigned char * mpi_export_buffer;
++  unsigned char mpi_serial_int = '1';
++  mpi_export_buffer = &mpi_serial_int;
+   unsigned char * primary_buffer;
+   unsigned char *certOffset;
+   unsigned char * output_buffer;
+@@ -181,7 +184,7 @@ static int cert_write(SSLCert &certCtx, std::string dn, std::string validityFrom
+   }
+ 
+   mbedtls_pk_init( &key );
+-  stepRes = mbedtls_pk_parse_key( &key, certCtx.getPKData(), certCtx.getPKLength(), NULL, 0 );
++  stepRes = mbedtls_pk_parse_key( &key, certCtx.getPKData(), certCtx.getPKLength(), NULL, 0, mbedtls_ctr_drbg_random, &ctr_drbg );
+   if (stepRes != 0) {
+     funcRes = HTTPS_SERVER_ERROR_CERTGEN_READKEY;
+     goto error_after_key;
+@@ -230,7 +233,7 @@ static int cert_write(SSLCert &certCtx, std::string dn, std::string validityFrom
+     funcRes = HTTPS_SERVER_ERROR_CERTGEN_SERIAL;
+     goto error_after_cert_serial;
+   }
+-  stepRes = mbedtls_x509write_crt_set_serial( &crt, &serial );
++  stepRes = mbedtls_x509write_crt_set_serial_raw( &crt, mpi_export_buffer, 1 ); // FIXME: skooch bug
+   if (stepRes != 0) {
+     funcRes = HTTPS_SERVER_ERROR_CERTGEN_SERIAL;
+     goto error_after_cert_serial;

--- a/src/mqtt/MQTT.cpp
+++ b/src/mqtt/MQTT.cpp
@@ -335,7 +335,7 @@ void MQTT::reconnect()
             mqttUsername = moduleConfig.mqtt.username;
             mqttPassword = moduleConfig.mqtt.password;
         }
-#if HAS_WIFI && !defined(ARCH_PORTDUINO)
+#if HAS_WIFI && !defined(ARCH_PORTDUINO) && defined(ESP_ARDUINO_VERSION_MAJOR) && ESP_ARDUINO_VERSION_MAJOR < 3
 #if !defined(CONFIG_IDF_TARGET_ESP32C6) && !defined(RPI_PICO)
         if (moduleConfig.mqtt.tls_enabled) {
             // change default for encrypted to 8883

--- a/src/platform/esp32/main-esp32.cpp
+++ b/src/platform/esp32/main-esp32.cpp
@@ -152,16 +152,16 @@ void esp32Setup()
 // #define APP_WATCHDOG_SECS 45
 #define APP_WATCHDOG_SECS 90
 
-#ifdef CONFIG_IDF_TARGET_ESP32C6
+// #ifdef CONFIG_IDF_TARGET_ESP32C6
     esp_task_wdt_config_t *wdt_config = (esp_task_wdt_config_t *)malloc(sizeof(esp_task_wdt_config_t));
     wdt_config->timeout_ms = APP_WATCHDOG_SECS * 1000;
     wdt_config->trigger_panic = true;
     res = esp_task_wdt_init(wdt_config);
     assert(res == ESP_OK);
-#else
-    res = esp_task_wdt_init(APP_WATCHDOG_SECS, true);
-    assert(res == ESP_OK);
-#endif
+// #else
+//     res = esp_task_wdt_init(APP_WATCHDOG_SECS, true);
+//     assert(res == ESP_OK);
+// #endif
     res = esp_task_wdt_add(NULL);
     assert(res == ESP_OK);
 

--- a/src/power.h
+++ b/src/power.h
@@ -6,6 +6,7 @@
 
 #ifdef ARCH_ESP32
 // "legacy adc calibration driver is deprecated, please migrate to use esp_adc/adc_cali.h and esp_adc/adc_cali_scheme.h
+#include <driver/adc.h>
 #include <esp_adc_cal.h>
 #include <soc/adc_channel.h>
 #endif

--- a/variants/t-deck/variant.h
+++ b/variants/t-deck/variant.h
@@ -47,6 +47,7 @@
 // ratio of voltage divider = 2.0 (RD2=100k, RD3=100k)
 #define ADC_MULTIPLIER 2.11 // 2.0 + 10% for correction of display undervoltage.
 #define ADC_CHANNEL ADC1_GPIO4_CHANNEL
+#define BAT_MEASURE_ADC_UNIT 2
 
 // keyboard
 #define I2C_SDA 18 // I2C pins for this board


### PR DESCRIPTION
`CONFLICT! driver_ng is not allowed to be used with the legacy driver` which is due to somehow including the legacy AND the new driver but I can't be screwed finding where the new driver is rn.